### PR TITLE
Only play cooldown audio if tab is not focused & Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# rPlace 2 - An open source faithful recreation of r/place
+
+This site aims to be as similar to the april fools r/place event, where users were given a 2000x2000px canvas, allowing anyone to draw a single on it at a time. 
+
+"Alone you can create something, but together, you can create something more" (or something like that)
+
+Site link: https://rplace.tk
+
+*Feel free to contribute!*

--- a/index.html
+++ b/index.html
@@ -267,10 +267,10 @@
 		setInterval(() => {
 			let left = Math.floor((CD - Date.now()) / 1000)
 			place.innerHTML = left > 0 ? `<svg xmlns="http://www.w3.org/2000/svg" data-name="icons final" viewBox="0 0 20 20" style="height: 1.1rem;vertical-align:top"><path d="M13.558 14.442l-4.183-4.183V4h1.25v5.741l3.817 3.817-.884.884z"></path><path d="M10 19.625A9.625 9.625 0 1119.625 10 9.636 9.636 0 0110 19.625zm0-18A8.375 8.375 0 1018.375 10 8.384 8.384 0 0010 1.625z"></path></svg> ${(''+Math.floor(left/3600)).padStart(2,"0")}:${(''+Math.floor((left/60))%60).padStart(2,"0")}:${(''+left%60).padStart(2,"0")}` : "Place a tile"
-			if(CD > Date.now() && !onCooldown)onCooldown = true
+			if(CD > Date.now() && !onCooldown) onCooldown = true
 			if(CD < Date.now() && onCooldown){
 				onCooldown = false
-				audios.cooldownEnd.run()
+				if (!document.hasFocus()) audios.cooldownEnd.run()
 			}
 		}, 300)
 


### PR DESCRIPTION
User said it was annoying playing audio if he could clearly see that his cooldown had ended